### PR TITLE
[build] Disable AppImage builds

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
     },
     "bundle": {
       "active": true,
-      "targets": "all",
+      "targets": ["deb", "rpm"],
       "identifier": "au.cantcontrol.driverstation",
       "icon": [
         "icons/32x32.png",


### PR DESCRIPTION
AppImage builds are really slow and a notoriously bad format.